### PR TITLE
add require for Forwardable

### DIFF
--- a/lib/rubex.rb
+++ b/lib/rubex.rb
@@ -1,3 +1,5 @@
+require 'forwardable'
+
 require 'rubex/compiler_config'
 require 'rubex/error'
 require 'rubex/helpers'


### PR DESCRIPTION
Thank you for your ingenious work. I am not a professional programmer or engineer, but I am very interested in this project. it is very fun.

When I tried Rubex for the first time, "forwardable" was not loaded and an error occurred.  
```shell
rubex-0.0.1/lib/rubex/ast/expression.rb:886:in `<class:CoerceObject>': uninitialized constant Rubex::AST::Expression::CoerceObject::Forwardable (NameError)
```

 lib/rubex/ast/expression.rb
line 886
```ruby
        extend Forwardable 
```

'bundle exec' loads 'pry'. And 'pry' seems to load 'forwardable'. 
I add 'require forwordable' to lib/rubex.rb
Thank you. 