### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Rubex is complimentary to Ruby. It DOES NOT aim to be a replacement for Ruby.
 
 The gem as of now has not reached v0.1. However, you can try it out with:
 ```
-git clone https://github.com/v0dro/Rubex::Compiler.git
+git clone https://github.com/v0dro/rubex.git
 cd rubex
 bundle install
 rake install
@@ -250,7 +250,7 @@ end
 
 ## Statements and Expressions
 
-All expressions that are supported in Ruby are supported in Rubex::Compiler. You can also intermingle C and Ruby types in the same expression, subject to some restrictions.
+All expressions that are supported in Ruby are supported in Rubex. You can also intermingle C and Ruby types in the same expression, subject to some restrictions.
 
 ### Implicit type conversions
 


### PR DESCRIPTION
I replaced 'Rubex :: Compiler' in README.md to 'Rubex'.

The idiom below does not work on my computer, but I thought that it might be undergoing elaboration and left it as it was.
```ruby
lib "<math.h>" do # "do" is obsolete? 
end

class
 # cant call functions here?
end
```

I am actually an amateur who can not read and write scripts other than Ruby but the product that kou started a few days ago may be similar to rubex. 
https://github.com/red-data-tools/extpp
I hope that someone using Rubex will speed up the existing ruby gems. 

Thank you.